### PR TITLE
Resize HImage's internal _image.

### DIFF
--- a/pde/HImage.pde
+++ b/pde/HImage.pde
@@ -11,6 +11,13 @@ public static class HImage extends HDrawable {
 		copy.copyPropertiesFrom(this);
 		return copy;
 	}
+	public HImage size(float w, float h) {
+		super.size(w, h);
+		if (_image.width != w || _image.height != h) {
+			_image.resize((int)w, (int)h);
+		}
+		return this;
+	}
 	public HImage resetSize() {
 		if(_image == null) size(0f,0f);
 		else size(_image.width, _image.height);


### PR DESCRIPTION
The internal _image (of type PImage) must be resized because certain HYPE funcationality depends on this internal image. An example is HPixelColorist which uses PImage's `get` function to retrieve the pixel color information. Therefore, without resizing _image, if you pass an HImage that has been resized into HPixelColorist, the pixel colors are retrieved from the original size and not the new size.
