### PR TITLE
Fix for jar.

### DIFF
--- a/java/src/hype/extended/behavior/HMagneticField.java
+++ b/java/src/hype/extended/behavior/HMagneticField.java
@@ -19,6 +19,7 @@ import hype.core.util.HMath;
 import java.util.ArrayList;
 
 import processing.core.PApplet;
+import processing.core.PVector;
 
 public class HMagneticField extends HBehavior {
 	private ArrayList<HPole> _poles;
@@ -89,14 +90,14 @@ public class HMagneticField extends HBehavior {
 			d = distance.mag() / 5;
 
 			distance.normalize();
-			distance.mult(abs(p._polarity));
+			distance.mult(Math.abs(p._polarity));
 			distance.div(d);
 
 			force.add(distance);
 
 		}
 
-    	return atan2(force.y, force.x);
+    	return processing.core.PApplet.atan2(force.y, force.x);
 
 		
 	}

--- a/java/src/hype/extended/behavior/HOscillator.java
+++ b/java/src/hype/extended/behavior/HOscillator.java
@@ -13,9 +13,11 @@ package hype.extended.behavior;
 
 import hype.core.behavior.HBehavior;
 import hype.core.drawable.HDrawable;
+import hype.core.drawable.HDrawable3D;
 import hype.core.util.HConstants;
 import hype.core.util.HMath;
 import processing.core.PApplet;
+import processing.core.PVector;
 
 public class HOscillator extends HBehavior {
 	private HDrawable _target;


### PR DESCRIPTION
A new, clean patch for missing imports, allowing creation of a viable jar. First referenced in [#67](https://github.com/hype/HYPE_Processing/issues/67), first cut at a patch in (closed) [#70](https://github.com/hype/HYPE_Processing/pull/70).
This should apply cleanly, and has been tested in the PDE in Java mode (as well as with `processing-java`, and in the PDE in Python mode. Standalone Python is experiencing some library resolving difficulties at the moment).
The `atan2` call on line 100 of HMagneticField is a horror, but it won't resolve any other way, and I can't figure out why. I am certainly open to enlightenment.