### PR TITLE
moving loadPixels() to after beginDraw() should resolve #87

### DIFF
--- a/src/main/java/hype/HCanvas.java
+++ b/src/main/java/hype/HCanvas.java
@@ -48,8 +48,8 @@ public class HCanvas extends HDrawable {
 		int h = Math.round(_height);
 
 		_graphics = H.app().createGraphics(w, h, _renderer);
-		_graphics.loadPixels();
 		_graphics.beginDraw();
+		_graphics.loadPixels();
 			_graphics.background(H.CLEAR);
 		_graphics.endDraw();
 


### PR DESCRIPTION
I tested with 3.0, default renderer and `P2D`.