### PR TITLE
Update HOscillator.java

### DIFF
--- a/src/main/java/hype/extended/behavior/HOscillator.java
+++ b/src/main/java/hype/extended/behavior/HOscillator.java
@@ -392,6 +392,17 @@ public class HOscillator extends HBehavior {
 	public void runBehavior(PApplet app) {
 		if(target ==null) return;
 
+//FIX FOR H.SCALE AND METHOD CHAINING ON HBOX
+    if (target instanceof HDrawable3D) {
+      if (max2 != max3) {
+        max3=max2;
+      }
+      if (min2 != min3) {
+       min3=min2;
+      }
+    }
+// END FIX FOR H.SCALE AND METHOD CHAINING ON HBOX
+
 		nextRaw();
 		float v1 = curr1;
 		float v2 = curr2;


### PR DESCRIPTION
Fixes minor bug. If HOscillator().range appeared before HOscillator().target (as per below), then min3 and max3 would not be properly set when using H.SCALE on a HDrawable 3D. Proposed change means that method chaining for HOscillator should work, even when range appears before target.
 
//EXAMPLE - new HOscillator().range(0.75, 1.75).target(d).property(H.SCALE).currentStep(1).speed(1.6).freq(2.3);