### PR TITLE
Update README.md - link to hypeframework.org

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A project maintained by [Joshua Davis](https://github.com/hype/) / [twitter.com/
 
 A collection of classes that performs the heavy lifting for you by writing a minimal amount of code.
 
-More about HYPE here.
+More about HYPE [here](http://www.hypeframework.org/).
 
 This library is currently under heavy development. You can keep track of the latest changes here in the [CHANGELOG][1].
 


### PR DESCRIPTION
The README just says 'More about HYPE here' without actually linking to anything. I assume the original intent was to link to something that would give people a good sense of what this is about, and hypeframework.org seems to be such a thing.
